### PR TITLE
bugfix: add missing raw in the metric struct

### DIFF
--- a/shibuya/controller/jmeter.go
+++ b/shibuya/controller/jmeter.go
@@ -131,6 +131,7 @@ func (je *jmeterEngine) readMetrics() chan *shibuyaMetric {
 					label:        label,
 					status:       status,
 					latency:      latency,
+					raw:          raw,
 					collectionID: strconv.FormatInt(je.collectionID, 10),
 					planID:       strconv.FormatInt(je.planID, 10),
 					engineID:     strconv.FormatInt(int64(je.ID), 10),


### PR DESCRIPTION
The `raw` was missed during refactoring. 

Currently local is broken with the file storage so cannot verify it. But it should be the culprit. 