### PR TITLE
add launch history, make billing easier

### DIFF
--- a/shibuya/db/20200722.sql
+++ b/shibuya/db/20200722.sql
@@ -4,8 +4,9 @@ CREATE TABLE IF NOT EXISTS collection_launch_history
 (
     collection_id INT UNSIGNED NOT NULL,
     context varchar(20) NOT NULL,
+    owner VARCHAR(50) NOT NULL,
     engines_count INT UNSIGNED,
-    machines_count INT UNSIGNED,
+    nodes_count INT UNSIGNED,
     started_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     end_time TIMESTAMP NULL DEFAULT NULL,
     key(collection_id, started_time)

--- a/shibuya/db/20200722.sql
+++ b/shibuya/db/20200722.sql
@@ -1,0 +1,12 @@
+use shibuya;
+
+CREATE TABLE IF NOT EXISTS collection_launch_history
+(
+    collection_id INT UNSIGNED NOT NULL,
+    context varchar(20) NOT NULL,
+    engines_count INT UNSIGNED,
+    machines_count INT UNSIGNED,
+    started_time TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    end_time TIMESTAMP NULL DEFAULT NULL,
+    key(collection_id, started_time)
+)CHARSET=utf8mb4;

--- a/shibuya/model/collection.go
+++ b/shibuya/model/collection.go
@@ -535,15 +535,15 @@ func (c *Collection) FetchCollectionFiles() error {
 	return hasError
 }
 
-func (c *Collection) NewLaunchEntry(context string, enginesCount, machinesCount int64) error {
+func (c *Collection) NewLaunchEntry(owner, context string, enginesCount, machinesCount int64) error {
 	DBC := config.SC.DBC
-	q, err := DBC.Prepare("insert collection_launch_history set collection_id=?,context=?,engines_count=?,machines_count=?")
+	q, err := DBC.Prepare("insert collection_launch_history set collection_id=?,context=?,engines_count=?,nodes_count=?,owner=?")
 	if err != nil {
 		return err
 	}
 	defer q.Close()
 
-	_, err = q.Exec(c.ID, context, enginesCount, machinesCount)
+	_, err = q.Exec(c.ID, context, enginesCount, machinesCount, owner)
 	if err != nil {
 		return err
 	}

--- a/shibuya/model/collection.go
+++ b/shibuya/model/collection.go
@@ -534,3 +534,36 @@ func (c *Collection) FetchCollectionFiles() error {
 	wgFetchData.Wait()
 	return hasError
 }
+
+func (c *Collection) NewLaunchEntry(context string, enginesCount, machinesCount int64) error {
+	DBC := config.SC.DBC
+	q, err := DBC.Prepare("insert collection_launch_history set collection_id=?,context=?,engines_count=?,machines_count=?")
+	if err != nil {
+		return err
+	}
+	defer q.Close()
+
+	_, err = q.Exec(c.ID, context, enginesCount, machinesCount)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (c *Collection) MarkUsageFinished() error {
+	db := config.SC.DBC
+
+	// in case there is failure in the previous update, we could have multiple entries with null endtime
+	// pick the latest one
+	q, err := db.Prepare("update collection_launch_history set end_time=NOW() where collection_id=? and end_time is null order by started_time desc limit 1")
+	if err != nil {
+		return err
+	}
+	defer q.Close()
+
+	_, err = q.Exec(c.ID)
+	if err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
Basic logic:

For every engine launched, we will record down the history, when the engines were and launched and purged. It will be easier to calculate the actual cost.

For non on-demand cluster, machines will be zero. For on-demand cluster, we will record down both engines and machines.


1. Please review the database schema first
2. I have not tested the on-demand cluster, will test it soon. 
