### PR TITLE
switch from docker.io to gcr.io for building images

### DIFF
--- a/grafana/Dockerfile
+++ b/grafana/Dockerfile
@@ -1,4 +1,4 @@
-FROM grafana/grafana:5.3.2
+FROM gcr.io/shibuya-214807/grafana/grafana:5.3.2
 ENV GF_SECURITY_ADMIN_USER=shibuya
 ENV GF_SECURITY_ADMIN_PASSWORD=shibuya
 ENV GF_AUTH_ANONYMOUS_ENABLED=true

--- a/jmeter/Dockerfile
+++ b/jmeter/Dockerfile
@@ -1,18 +1,18 @@
 ARG jmeter_ver=3.3
 
-FROM alpine:3.10.2 AS jmeter
+FROM gcr.io/shibuya-214807/alpine:3.10.2 AS jmeter
 ARG jmeter_ver
 ENV JMETER_VERSION=$jmeter_ver
 RUN wget https://archive.apache.org/dist/jmeter/binaries/apache-jmeter-${JMETER_VERSION}.zip
 RUN unzip -qq apache-jmeter-${JMETER_VERSION}
 
-FROM golang:1.13.6-stretch AS shibuya-agent
+FROM gcr.io/shibuya-214807/golang:1.13.6-stretch AS shibuya-agent
 RUN go get github.com/hpcloud/tail
 ADD shibuya-agent.go /go/src/shibuya-agent/shibuya-agent.go
 WORKDIR /go/src/shibuya-agent
 RUN GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build  -o /go/bin/shibuya-agent
 
-FROM openjdk:8u212-jdk
+FROM gcr.io/shibuya-214807/openjdk:8u212-jdk
 ARG jmeter_ver
 ENV JMETER_VERSION=$jmeter_ver
 RUN mkdir /test-conf /test-result

--- a/local_storage/Dockerfile
+++ b/local_storage/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.6-stretch
+FROM gcr.io/shibuya-214807/golang:1.13.6-stretch
 
 WORKDIR /go/src/storage
 ADD go.mod go.mod

--- a/shibuya/Dockerfile
+++ b/shibuya/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13.6-stretch AS builder
+FROM gcr.io/shibuya-214807/golang:1.13.6-stretch AS builder
 
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl \
     && chmod +x ./kubectl \
@@ -17,7 +17,7 @@ COPY . /go/src/shibuya
 RUN GOOS=linux GOARCH=amd64 go build -ldflags="-w -s" -o /go/bin/shibuya
 
 # Use only binaries from above image for running the app
-FROM ubuntu:18.04
+FROM gcr.io/shibuya-214807/ubuntu:18.04
 
 COPY --from=builder /go/bin/shibuya /usr/local/bin/shibuya
 COPY --from=builder /usr/local/bin/kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
Hitting the docker pull limits when building from local and CI/CD, so switching to gcr instead