### PR TITLE
Performance improvements

### DIFF
--- a/shibuya/config/init.go
+++ b/shibuya/config/init.go
@@ -94,11 +94,15 @@ type LogFormat struct {
 type IngressConfig struct {
 	Image    string `json:"image"`
 	Replicas int32  `json:"replicas"`
+	CPU      string `json:"cpu"`
+	Mem      string `json:"mem"`
 }
 
 var defaultIngressConfig = IngressConfig{
 	Image:    "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.20.0",
 	Replicas: 1,
+	CPU:      "2",
+	Mem:      "1Gi",
 }
 
 type ShibuyaConfig struct {

--- a/shibuya/config/init.go
+++ b/shibuya/config/init.go
@@ -92,11 +92,13 @@ type LogFormat struct {
 }
 
 type IngressConfig struct {
-	Image string `json:"image"`
+	Image    string `json:"image"`
+	Replicas int32  `json:"replicas"`
 }
 
 var defaultIngressConfig = IngressConfig{
-	Image: "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.20.0",
+	Image:    "quay.io/kubernetes-ingress-controller/nginx-ingress-controller:0.20.0",
+	Replicas: 1,
 }
 
 type ShibuyaConfig struct {

--- a/shibuya/config/init.go
+++ b/shibuya/config/init.go
@@ -128,7 +128,16 @@ func loadContext() string {
 }
 
 func (sc *ShibuyaConfig) makeHTTPClients() {
-	sc.HTTPClient = &http.Client{}
+	// Customize the Transport to have larger connection pool
+	defaultRoundTripper := http.DefaultTransport
+	defaultTransportPointer, ok := defaultRoundTripper.(*http.Transport)
+	if !ok {
+		log.Fatalln("defaultRoundTripper not an *http.Transport")
+	}
+	defaultTransport := *defaultTransportPointer
+	defaultTransport.MaxIdleConns = 1000
+	defaultTransport.MaxIdleConnsPerHost = 100
+	sc.HTTPClient = &http.Client{Transport: &defaultTransport}
 	sc.HTTPProxyClient = sc.HTTPClient
 	if sc.HttpConfig.Proxy == "" {
 		return
@@ -138,7 +147,9 @@ func (sc *ShibuyaConfig) makeHTTPClients() {
 		log.Fatal(err)
 	}
 	rt := &http.Transport{
-		Proxy: http.ProxyURL(proxyUrl),
+		Proxy:               http.ProxyURL(proxyUrl),
+		MaxIdleConns:        1000,
+		MaxIdleConnsPerHost: 100,
 	}
 	sc.HTTPProxyClient = &http.Client{Transport: rt}
 }

--- a/shibuya/config/init.go
+++ b/shibuya/config/init.go
@@ -128,16 +128,7 @@ func loadContext() string {
 }
 
 func (sc *ShibuyaConfig) makeHTTPClients() {
-	// Customize the Transport to have larger connection pool
-	defaultRoundTripper := http.DefaultTransport
-	defaultTransportPointer, ok := defaultRoundTripper.(*http.Transport)
-	if !ok {
-		log.Fatalln("defaultRoundTripper not an *http.Transport")
-	}
-	defaultTransport := *defaultTransportPointer
-	defaultTransport.MaxIdleConns = 1000
-	defaultTransport.MaxIdleConnsPerHost = 100
-	sc.HTTPClient = &http.Client{Transport: &defaultTransport}
+	sc.HTTPClient = &http.Client{}
 	sc.HTTPProxyClient = sc.HTTPClient
 	if sc.HttpConfig.Proxy == "" {
 		return
@@ -147,9 +138,7 @@ func (sc *ShibuyaConfig) makeHTTPClients() {
 		log.Fatal(err)
 	}
 	rt := &http.Transport{
-		Proxy:               http.ProxyURL(proxyUrl),
-		MaxIdleConns:        1000,
-		MaxIdleConnsPerHost: 100,
+		Proxy: http.ProxyURL(proxyUrl),
 	}
 	sc.HTTPProxyClient = &http.Client{Transport: rt}
 }

--- a/shibuya/scheduler/k8s.go
+++ b/shibuya/scheduler/k8s.go
@@ -100,9 +100,8 @@ func prepareAffinity(collectionID int64) *apiv1.Affinity {
 	if config.SC.ExecutorConfig.Cluster.OnDemand {
 		affinity.NodeAffinity = collectionNodeAffinity(collectionID)
 		return affinity
-	} else {
-		affinity.PodAffinity = collectionPodAffinity(collectionID)
 	}
+	affinity.PodAffinity = collectionPodAffinity(collectionID)
 	na := config.SC.ExecutorConfig.NodeAffinity
 	if len(na) > 0 {
 		t := na[0]

--- a/shibuya/scheduler/k8s.go
+++ b/shibuya/scheduler/k8s.go
@@ -516,7 +516,7 @@ func (kcm *K8sClientManager) generateControllerDeployment(igName string, collect
 			Labels: labels,
 		},
 		Spec: appsv1.DeploymentSpec{
-			Replicas: int32Ptr(1),
+			Replicas: int32Ptr(config.SC.IngressConfig.Replicas),
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,
 			},

--- a/shibuya/scheduler/k8s.go
+++ b/shibuya/scheduler/k8s.go
@@ -562,6 +562,13 @@ func (kcm *K8sClientManager) generateControllerDeployment(igName string, collect
 						{
 							Name:  "nginx-ingress-controller",
 							Image: config.SC.IngressConfig.Image,
+							Resources: apiv1.ResourceRequirements{
+								// Limits are whatever Kubernetes sets as the max value
+								Requests: apiv1.ResourceList{
+									apiv1.ResourceCPU:    resource.MustParse(config.SC.IngressConfig.CPU),
+									apiv1.ResourceMemory: resource.MustParse(config.SC.IngressConfig.Mem),
+								},
+							},
 							Args: []string{
 								"/nginx-ingress-controller",
 								fmt.Sprintf("--ingress-class=%s", igName),

--- a/shibuya/ui/static/js/common.js
+++ b/shibuya/ui/static/js/common.js
@@ -1,5 +1,5 @@
 var EventBus = new Vue();
-var SYNC_INTERVAL = 10000;
+var SYNC_INTERVAL = 5000;
 Vue.http.options.root = "/api";
 Vue.http.options.emulateJSON = true;
 

--- a/shibuya/ui/static/js/common.js
+++ b/shibuya/ui/static/js/common.js
@@ -1,5 +1,5 @@
 var EventBus = new Vue();
-var SYNC_INTERVAL = 3000;
+var SYNC_INTERVAL = 10000;
 Vue.http.options.root = "/api";
 Vue.http.options.emulateJSON = true;
 


### PR DESCRIPTION
1. Fetching status has a pretty big impact on the cpu and connection usage of controller. If status starts failing it creates a never ending leak of goroutines. 10s seems good enough balance. This part requires further optimization
2. When the number of engines is high enough, it can cause issues on nginx controller. Also there could be cpu contention happening on the nodes engines are running, so having multiple replicas reduces the impact
3. Learning from golang load generators - https://github.com/tsenart/vegeta/blob/master/lib/attack.go#L115-L129 the default http client settings are too low for such cases. So we need to increase it to higher values. 
4. In a shared cluster (the default for shibuya) there is possibility of noisy neighbour affecting each other, so the preference should be to club together engines of same collections