### PR TITLE
Ensure the launch history is correct

### DIFF
--- a/shibuya/api/main.go
+++ b/shibuya/api/main.go
@@ -697,7 +697,10 @@ func (s *ShibuyaAPI) collectionPurgeHandler(w http.ResponseWriter, r *http.Reque
 		s.handleErrors(w, err)
 		return
 	}
-	s.ctr.TermAndPurgeCollectionAsync(collection)
+	if err = s.ctr.TermAndPurgeCollection(collection); err != nil {
+		s.handleErrors(w, err)
+		return
+	}
 }
 
 func (s *ShibuyaAPI) collectionNodesGetHandler(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {

--- a/shibuya/api/main.go
+++ b/shibuya/api/main.go
@@ -644,6 +644,11 @@ func (s *ShibuyaAPI) collectionDeploymentHandler(w http.ResponseWriter, r *http.
 		return
 	}
 	if err := s.ctr.DeployCollection(collection); err != nil {
+		var dbe *model.DBError
+		if errors.As(err, &dbe) {
+			s.handleErrors(w, makeInvalidRequestError(err.Error()))
+			return
+		}
 		s.handleErrors(w, makeInternalServerError(err.Error()))
 		return
 	}

--- a/shibuya/controller/collection.go
+++ b/shibuya/controller/collection.go
@@ -49,7 +49,12 @@ func (c *Controller) TermAndPurgeCollection(collection *model.Collection) error 
 		for _, ep := range eps {
 			vu += ep.Engines * ep.Concurrency
 		}
-		collection.MarkUsageFinished(config.SC.Context, int64(vu))
+		launchID, err := collection.GetLaunchID()
+		if err != nil {
+			return err
+		}
+		collection.MarkUsageFinished(config.SC.Context, launchID, int64(vu))
+		collection.CleanLaunch()
 	}
 	return err
 }

--- a/shibuya/controller/collection.go
+++ b/shibuya/controller/collection.go
@@ -42,17 +42,13 @@ func (c *Controller) TermAndPurgeCollection(collection *model.Collection) error 
 	if err != nil {
 		return err
 	}
-	launchID, _ := collection.GetLaunchID()
-	// Since collection can be purged multiple times, we need to ensure that the billing is correct.
-	if launchID != 0 {
-		vu := 0
-		for _, ep := range eps {
-			vu += ep.Engines * ep.Concurrency
-		}
-		err = collection.MarkUsageFinished(config.SC.Context, launchID, int64(vu))
-		if err != nil {
-			return err
-		}
+	vu := 0
+	for _, ep := range eps {
+		vu += ep.Engines * ep.Concurrency
+	}
+	err = collection.MarkUsageFinished(config.SC.Context, int64(vu))
+	if err != nil {
+		return err
 	}
 	return c.Scheduler.PurgeCollection(collection.ID)
 }

--- a/shibuya/controller/main.go
+++ b/shibuya/controller/main.go
@@ -198,12 +198,9 @@ func (c *Controller) DeployCollection(collection *model.Collection) error {
 	if project, err := model.GetProject(collection.ProjectID); err == nil {
 		owner = project.Owner
 	}
-	launchID, err := collection.StartLaunch()
-	if err != nil {
+	if err := collection.NewLaunchEntry(owner, config.SC.Context, int64(enginesCount), nodesCount, int64(vu)); err != nil {
 		return err
 	}
-	collection.NewLaunchEntry(owner, config.SC.Context, launchID, int64(enginesCount), nodesCount, int64(vu))
-
 	err = utils.Retry(func() error {
 		return c.Scheduler.ExposeCollection(collection.ProjectID, collection.ID)
 	}, nil)

--- a/shibuya/controller/main.go
+++ b/shibuya/controller/main.go
@@ -198,7 +198,11 @@ func (c *Controller) DeployCollection(collection *model.Collection) error {
 	if project, err := model.GetProject(collection.ProjectID); err == nil {
 		owner = project.Owner
 	}
-	collection.NewLaunchEntry(owner, config.SC.Context, int64(enginesCount), nodesCount, int64(vu))
+	launchID, err := collection.StartLaunch()
+	if err != nil {
+		return err
+	}
+	collection.NewLaunchEntry(owner, config.SC.Context, launchID, int64(enginesCount), nodesCount, int64(vu))
 
 	err = utils.Retry(func() error {
 		return c.Scheduler.ExposeCollection(collection.ProjectID, collection.ID)

--- a/shibuya/db/20220805.sql
+++ b/shibuya/db/20220805.sql
@@ -1,0 +1,9 @@
+use shibuya;
+
+CREATE TABLE IF NOT EXISTS collection_launch (
+    id INT unsigned NOT NULL AUTO_INCREMENT PRIMARY KEY,
+    collection_id INT unsigned NOT NULL UNIQUE
+)CHARSET=utf8mb4;
+
+ALTER TABLE collection_launch_history2 ADD COLUMN launch_id INT unsigned NOT NULL AFTER owner,
+ADD INDEX (launch_id);


### PR DESCRIPTION
This PR is trying to fix following issues:

1. User could launch multiple times. This could cause incorrect launch record. So we only one record per launch.
2. User could also purge multiple times. Again, we should only record once. 
3. Some times, purging at k8s side can fail because the collection is large and this could cause the usage record to be lost because of poor error handling.

**How**
1. We add a unique constraint in `collection_launch` table. When user launches the first time, we add a row into the table(and get a unique id, `launch_id`, this will be used in collection_launch_history). Second launch will be rejected.
2. When user purges the collection, the `launch_id` is used to find the row in `collection_launch_history2` to add the finish time.
3. We use `defer` to handle the usage record regardless whether k8s api server will return an error not. It will be executed on the func return.