### PR TITLE
use go built-in reverse proxy module

### DIFF
--- a/ingress-controller/Dockerfile
+++ b/ingress-controller/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/shibuya-214807/golang:1.17-stretch AS builder
+FROM gcr.io/shibuya-214807/golang:1.20.2-buster AS builder
 
 WORKDIR /go/src/shibuya-ingress-controller
 

--- a/ingress-controller/go.mod
+++ b/ingress-controller/go.mod
@@ -1,6 +1,6 @@
 module ingress-controller
 
-go 1.17
+go 1.20
 
 require (
 	github.com/sirupsen/logrus v1.9.0

--- a/ingress-controller/main.go
+++ b/ingress-controller/main.go
@@ -185,6 +185,10 @@ func makeAccessLogEntry(statusCode int, path string) string {
 	return fmt.Sprintf("%d, %s", statusCode, path)
 }
 
+// This func does two things:
+// 1. It rewrites ingress ip to engine ip.
+// 2. It rewrites path by removing engine id info.
+// Usage of this func is guided by code here: https://github.com/golang/go/blob/go1.20.2/src/net/http/httputil/reverseproxy.go#L42
 func (sic *ShibuyaIngressController) rewriteURL(r *httputil.ProxyRequest) {
 	// When we encoutered an error, the rewrite won't happen. Controller side should see 502
 	// Which is the expected behaviour from reverse proxy POV.


### PR DESCRIPTION
Should've used this module at the beginning. It resolved two issues:

1. Graph smoothness. Previously, during metrics streaming, when using `io.Copy`, bytes in buffer were flushed in batch so we can see requests increase is not smooth at controller side(one batch might have 10 lines of data, one batch might have 12 lines of data). Address the issue mentioned here: https://github.com/rakutentech/shibuya/issues/80
2. Much more protocol compatible as the std lib has taken care much of it. 