### PR TITLE
Engine metrics deletion

### DIFF
--- a/shibuya/controller/collection.go
+++ b/shibuya/controller/collection.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"strconv"
 	"sync"
 
 	"github.com/rakutentech/shibuya/shibuya/config"
@@ -58,6 +59,13 @@ func (c *Controller) TermAndPurgeCollection(collection *model.Collection) (err e
 	c.TermCollection(collection, true)
 	if err = c.Scheduler.PurgeCollection(collection.ID); err != nil {
 		return err
+	}
+	eps, err := collection.GetExecutionPlans()
+	if err != nil {
+		return err
+	}
+	for _, p := range eps {
+		c.deleteEngineHealthMetrics(strconv.Itoa(int(collection.ID)), strconv.Itoa(int(p.PlanID)), p.Engines)
 	}
 	return err
 }

--- a/shibuya/controller/engine.go
+++ b/shibuya/controller/engine.go
@@ -249,11 +249,13 @@ func generateEnginesWithUrl(enginesRequired int, planID, collectionID, projectID
 func (ctr *Controller) fetchEngineMetrics() {
 	for {
 		time.Sleep(5 * time.Second)
-		deployedCollections, err := ctr.Scheduler.GetDeployedCollections()
+		// compared to previous approach(getting the deploy collection from the target k8s cluster), this one can
+		// reduce the engine metrics when there are multiple controller pointing to the same cluster
+		deployedCollections, err := model.GetLaunchingCollectionByContext(config.SC.Context)
 		if err != nil {
 			continue
 		}
-		for collectionID := range deployedCollections {
+		for _, collectionID := range deployedCollections {
 			c, err := model.GetCollection(collectionID)
 			if err != nil {
 				continue

--- a/shibuya/controller/engine.go
+++ b/shibuya/controller/engine.go
@@ -268,6 +268,7 @@ func (ctr *Controller) fetchEngineMetrics() {
 				if err != nil {
 					// Some schedulers might not have the feature to expose the metrics
 					// We will return directly
+					log.Warn(err)
 					if errors.Is(err, scheduler.FeatureUnavailable) {
 						return
 					}

--- a/shibuya/controller/prometheus.go
+++ b/shibuya/controller/prometheus.go
@@ -40,23 +40,31 @@ func (c *Controller) removeLocally(id int64) {
 	c.StatusStore.Delete(id)
 }
 
-func (c *Controller) deleteMetrics(runID string, collectionID string, planID string, engines int) {
+func (c *Controller) deleteEngineHealthMetrics(collectionID string, planID string, engines int) {
 	for i := 0; i < engines; i++ {
-		config.ThreadsGauge.Delete(prometheus.Labels{
-			"collection_id": collectionID,
-			"plan_id":       planID,
-			"run_id":        runID,
-			"engine_no":     strconv.Itoa(i),
-		})
+		engineID := strconv.Itoa(i)
 		config.CpuGauge.Delete(prometheus.Labels{
 			"collection_id": collectionID,
 			"plan_id":       planID,
-			"engine_no":     strconv.Itoa(i),
+			"engine_no":     engineID,
 		})
 		config.MemGauge.Delete(prometheus.Labels{
 			"collection_id": collectionID,
 			"plan_id":       planID,
-			"engine_no":     strconv.Itoa(i),
+			"engine_no":     engineID,
+		})
+		log.Infof("Delete engine health metrics %s-%s-%s", collectionID, planID, engineID)
+	}
+}
+
+func (c *Controller) deleteMetrics(runID string, collectionID string, planID string, engines int) {
+	for i := 0; i < engines; i++ {
+		engineID := strconv.Itoa(i)
+		config.ThreadsGauge.Delete(prometheus.Labels{
+			"collection_id": collectionID,
+			"plan_id":       planID,
+			"run_id":        runID,
+			"engine_no":     engineID,
 		})
 	}
 	config.PlanLatencySummary.Delete(prometheus.Labels{

--- a/shibuya/model/collection.go
+++ b/shibuya/model/collection.go
@@ -579,3 +579,25 @@ func (c *Collection) MarkUsageFinished(cxt string, vu int64) error {
 	}
 	return tx.Commit()
 }
+
+// Get the current launching collection by context. The context is different per controller
+func GetLaunchingCollectionByContext(cxt string) ([]int64, error) {
+	db := config.SC.DBC
+	q, err := db.Prepare("select collection_id from collection_launch_history2 where context=? and end_time is null")
+	var collectionIDs []int64
+	if err != nil {
+		return collectionIDs, err
+	}
+	defer q.Close()
+	rs, err := q.Query(cxt)
+	if err != nil {
+		return collectionIDs, err
+	}
+	defer rs.Close()
+	for rs.Next() {
+		var cid int64
+		rs.Scan(&cid)
+		collectionIDs = append(collectionIDs, cid)
+	}
+	return collectionIDs, nil
+}


### PR DESCRIPTION
**Please be aware, the engine metrics refer to the cpu/mem of each engine, not the jmeter metrics controller collects.**

When multiple controller are pointing to the same k8s cluster, we can have redundant engine metrics. In the past, the engine metrics are managed by a background goroutine. But if the collection is not triggered by this particular controller, the local store will not have the meta data of the engines hence when they are going to be deleted, they cannot be deleted. With this PR, we move the engine metrics from local thread to purge. So when the engines are purged, the metrics are also purged.