### PR TITLE
Better release pipelines

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -10,11 +10,15 @@
 #
 # For more support on how to run the workflow, please visit https://github.com/google-github-actions/setup-gcloud/tree/master/example-workflows/gke-kustomize
 
-name: Build and Deploy to GCP registry
+name: Release(tag), Build and push to GCP registry
 
 on:
   push:
     branches: [ "split", "master" ]
+
+permissions:
+  contents: write
+  pull-requests: write
 
 env:
   GAR_LOCATION: asia-northeast1 # TODO: update region of the Artifact Registry
@@ -47,28 +51,43 @@ jobs:
       run: |-
         echo '${{ steps.auth.outputs.access_token }}' | docker login -u oauth2accesstoken --password-stdin https://$GAR_LOCATION-docker.pkg.dev
 
+    - uses: google-github-actions/release-please-action@v4
+      id: create_release
+      with:
+        # this assumes that you have created a personal access token
+        # (PAT) and configured it as a GitHub action secret named
+        # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+        token: ${{ secrets.GITHUB_TOKEN }}
+        # this is a built-in strategy in release-please, see "Action Inputs"
+        # for more options
+        release-type: simple
+
     # Build the Docker image
     - name: Build api
+      env:
+        tag_name: ${{ steps.create_release.outputs.tag_name }}
       run: |-
         cd shibuya && make api_image component=api
 
     - name: Build controller
+      env:
+        tag_name: ${{ steps.create_release.outputs.tag_name }}
       run: |-
         cd shibuya && make controller_image component=controller
 
-    - name: Configure Git
-      run: |
-        git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+    # - name: Configure Git
+    #   run: |
+    #     git config user.name "$GITHUB_ACTOR"
+    #     git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-    - name: Install Helm
-      uses: azure/setup-helm@v3
-      with:
-        version: "v3.13.3"
+    # - name: Install Helm
+    #   uses: azure/setup-helm@v3
+    #   with:
+    #     version: "v3.13.3"
 
-    - name: Run chart-releaser
-      uses: helm/chart-releaser-action@v1.5.0
-      with:
-        charts_dir: shibuya/install
-      env:
-        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    # - name: Run chart-releaser
+    #   uses: helm/chart-releaser-action@v1.5.0
+    #   with:
+    #     charts_dir: shibuya/install
+    #   env:
+    #     CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -31,7 +31,7 @@ jobs:
     outputs:
       tag_name: ${{ steps.create_release.outputs.tag_name }}
     steps:
-    - uses: google-github-actions/release-please-action@v4
+    - uses: googleapis/release-please-action@v4
       id: create_release
       with:
         # this assumes that you have created a personal access token

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -25,7 +25,26 @@ env:
   IMAGE: shibuya
 
 jobs:
+  release-please:
+    name: release-please
+    runs-on: ubuntu-20.04
+    outputs:
+      tag_name: ${{ steps.create_release.outputs.tag_name }}
+    steps:
+    - uses: google-github-actions/release-please-action@v4
+      id: create_release
+      with:
+        # this assumes that you have created a personal access token
+        # (PAT) and configured it as a GitHub action secret named
+        # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
+        token: ${{ secrets.GITHUB_TOKEN }}
+        # this is a built-in strategy in release-please, see "Action Inputs"
+        # for more options
+        release-type: simple
+
+
   setup-build-publish-deploy:
+    needs: release-please
     name: Setup, Build, Publish
     runs-on: ubuntu-20.04
     environment: production
@@ -51,27 +70,16 @@ jobs:
       run: |-
         echo '${{ steps.auth.outputs.access_token }}' | docker login -u oauth2accesstoken --password-stdin https://$GAR_LOCATION-docker.pkg.dev
 
-    - uses: google-github-actions/release-please-action@v4
-      id: create_release
-      with:
-        # this assumes that you have created a personal access token
-        # (PAT) and configured it as a GitHub action secret named
-        # `MY_RELEASE_PLEASE_TOKEN` (this secret name is not important).
-        token: ${{ secrets.GITHUB_TOKEN }}
-        # this is a built-in strategy in release-please, see "Action Inputs"
-        # for more options
-        release-type: simple
-
     # Build the Docker image
     - name: Build api
       env:
-        tag_name: ${{ steps.create_release.outputs.tag_name }}
+        tag_name: ${{ needs.release-please.outputs.tag_name }}
       run: |-
         cd shibuya && make api_image component=api
 
     - name: Build controller
       env:
-        tag_name: ${{ steps.create_release.outputs.tag_name }}
+        tag_name: ${{ needs.release-please.outputs.tag_name }}
       run: |-
         cd shibuya && make controller_image component=controller
 

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -48,6 +48,7 @@ jobs:
     name: Setup, Build, Publish
     runs-on: ubuntu-20.04
     environment: production
+    if: ${{ needs.release-please.outputs.tag_name != '' }}
 
     steps:
     - name: Checkout

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -84,19 +84,19 @@ jobs:
       run: |-
         cd shibuya && make controller_image component=controller
 
-    # - name: Configure Git
-    #   run: |
-    #     git config user.name "$GITHUB_ACTOR"
-    #     git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-    # - name: Install Helm
-    #   uses: azure/setup-helm@v3
-    #   with:
-    #     version: "v3.13.3"
+    - name: Install Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: "v3.13.3"
 
-    # - name: Run chart-releaser
-    #   uses: helm/chart-releaser-action@v1.5.0
-    #   with:
-    #     charts_dir: shibuya/install
-    #   env:
-    #     CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+    - name: Run chart-releaser
+      uses: helm/chart-releaser-action@v1.5.0
+      with:
+        charts_dir: shibuya/install
+      env:
+        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -43,9 +43,9 @@ jobs:
         release-type: simple
 
 
-  setup-build-publish-deploy:
+  setup-build-publish-push:
     needs: release-please
-    name: Setup, Build, Publish
+    name: Setup, Build, push
     runs-on: ubuntu-20.04
     environment: production
     if: ${{ needs.release-please.outputs.tag_name != '' }}

--- a/shibuya/Makefile
+++ b/shibuya/Makefile
@@ -7,7 +7,7 @@ upstream = rakutentech
 ifeq ($(GITHUB_REPOSITORY_OWNER), $(upstream))
 	tag=$(tag_name)
 else
-	tag=$(GITHUB_REPOSITORY)-$(tag_name)
+	tag=$(GITHUB_REPOSITORY_OWNER)-$(tag_name)
 endif
 
 .PHONY: api_build

--- a/shibuya/Makefile
+++ b/shibuya/Makefile
@@ -1,6 +1,6 @@
 registry=$(GAR_LOCATION)-docker.pkg.dev/$(GCP_PROJECT)
 repository = shibuya
-tag=$(GITHUB_SHA)
+tag=$(tag_name)
 img=$(registry)/$(repository)/$(component):$(tag)
 
 .PHONY: api_build

--- a/shibuya/Makefile
+++ b/shibuya/Makefile
@@ -2,6 +2,13 @@ registry=$(GAR_LOCATION)-docker.pkg.dev/$(GCP_PROJECT)
 repository = shibuya
 tag=$(tag_name)
 img=$(registry)/$(repository)/$(component):$(tag)
+upstream = rakutentech
+
+ifeq ($(GITHUB_REPOSITORY_OWNER), $(upstream))
+	tag=$(tag_name)
+else
+	tag=$(GITHUB_REPOSITORY)-$(tag_name)
+endif
 
 .PHONY: api_build
 api_build:

--- a/shibuya/install/shibuya/Chart.yaml
+++ b/shibuya/install/shibuya/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.0
+version: chart-v0.1.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
It's trying to address this issue: https://github.com/rakutentech/shibuya/issues/108

With this PR, we achieved:

1. Trunk based development: https://trunkbaseddevelopment.com/. This is basically the same as current workflow. All the PRs will be merged into master branch.
2. Once the PRs are merged, `release-please` will start to create the released PRs. An example: https://github.com/iandyh/shibuya/pull/8
3. When the release PRs are merged, `release-please` will create the tags/release automatically. Another job will start to build docker images and helm charts. A sample release: https://github.com/iandyh/shibuya/releases/tag/v1.2.0
4. If we want to rollback, we can simply use the previous artifact to rollback. 

By using `release-please`, developers need to follow https://www.conventionalcommits.org/. It's also better to squash merge the commits in order to follow the conventions. Then `release-please` is able to automatically create the release notes.