### PR TITLE
fix: chart issues in the pipeline

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -31,6 +31,7 @@ jobs:
     outputs:
       tag_name: ${{ steps.create_release.outputs.tag_name }}
     steps:
+
     - uses: googleapis/release-please-action@v4
       id: create_release
       with:
@@ -49,13 +50,7 @@ jobs:
     runs-on: ubuntu-20.04
     environment: production
     if: ${{ needs.release-please.outputs.tag_name != '' }}
-
     steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-      with:
-        fetch-depth: 0
-
     - name: Set up Go
       uses: actions/setup-go@v4
       with:
@@ -71,6 +66,29 @@ jobs:
       run: |-
         echo '${{ steps.auth.outputs.access_token }}' | docker login -u oauth2accesstoken --password-stdin https://$GAR_LOCATION-docker.pkg.dev
 
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Configure Git
+      run: |
+        git config user.name "$GITHUB_ACTOR"
+        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+    - name: Install Helm
+      uses: azure/setup-helm@v3
+      with:
+        version: "v3.13.3"
+
+    - name: build chart
+      env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |-
+        cd shibuya
+        make helm_charts
+        sh chart_releaser.sh
+
     # Build the Docker image
     - name: Build api
       env:
@@ -84,19 +102,6 @@ jobs:
       run: |-
         cd shibuya && make controller_image component=controller
 
-    - name: Configure Git
-      run: |
-        git config user.name "$GITHUB_ACTOR"
-        git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
-    - name: Install Helm
-      uses: azure/setup-helm@v3
-      with:
-        version: "v3.13.3"
 
-    - name: Run chart-releaser
-      uses: helm/chart-releaser-action@v1.5.0
-      with:
-        charts_dir: shibuya/install
-      env:
-        CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+

--- a/shibuya/Makefile
+++ b/shibuya/Makefile
@@ -30,5 +30,4 @@ controller_image: controller_build
 
 .PHONY: helm_charts
 helm_charts:
-	helm create shibuya-install
-	helm package shibuya-install/
+	helm package install/shibuya

--- a/shibuya/chart_releaser.sh
+++ b/shibuya/chart_releaser.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+chart_name=$(helm inspect chart install/shibuya | awk -F': ' '/^name:/ {print $2}')
+chart_version=$(helm inspect chart install/shibuya | awk -F': ' '/^version:/ {print $2}')
+chart_output=$chart_name-$chart_version
+if gh release view $chart_output; then
+    echo "Release already exists!"
+else
+    gh release create $chart_output --latest=false $chart_output.tgz --notes $chart_output -t $chart_output
+fi

--- a/shibuya/install/shibuya/Chart.yaml
+++ b/shibuya/install/shibuya/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-name: shibuya
-description: A Helm chart for Kubernetes
+name: shibuya-chart
+description: A Helm chart for deploying Shibuya
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: chart-v0.1.0
+version: v0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to


### PR DESCRIPTION
There are two issues:

1. Chart version should be semver compatible. 
2. Due to how chart-releaser works, it cannot build the chart based on generated tag. Instead, we will build the charts before tag generation. So once the charts are merged into master, we will build the charts.